### PR TITLE
Indent thread responsibilities under thread names

### DIFF
--- a/content/Engine/Structure.md
+++ b/content/Engine/Structure.md
@@ -40,44 +40,35 @@ Threads
 ### Stand-alone server
 
 * main
-
-* Doesn't do much
+  * Doesn't do much
 
 * ServerThread (Server)
-
-* Runs the server
+  * Runs the server
 
 * EmergeThread (Server)
-
-* Fetches and generates world
+  * Fetches and generates world
 
 ### Client-only
 
 * main
-
-* Runs almost everything in main game loop
+  * Runs almost everything in main game loop
 
 * MeshUpdateThread (Client)
-
-* Does mesh updates in the background
+  * Does mesh updates in the background
 
 ### Singleplayer
 
 * main
-
-* Runs almost everything except server in main game loop
+  * Runs almost everything except server in main game loop
 
 * MeshUpdateThread (Client)
-
-* Does mesh updates in the background
+  * Does mesh updates in the background
 
 * ServerThread (Server)
-
-* Runs the server
+  * Runs the server
 
 * EmergeThread (Server)
-
-* Fetches and generates world
+  * Fetches and generates world
 
 Classes
 -------


### PR DESCRIPTION
I think this adds clarity to which bullets in the list are names, and which are describing what the threads do.