### PR TITLE
Remove old TOC markers from the Voxelmanip Wiki

### DIFF
--- a/content/Engine/NMPR.md
+++ b/content/Engine/NMPR.md
@@ -11,8 +11,6 @@ Being around 10000 lines of code, it contains:
 
 NMPR has been made available at [<https://github.com/celeron55/minetest_nmpr>](https://github.com/celeron55/minetest_nmpr) (easiest to build). Older source release is [here (source)](http://c55.me/random/2013-01/minetest_10-10-24_16-33-41_wonderful.tar.gz) (build like [this](http://gist.github.com/4578183)). Also the [original win32 release](http://c55.me/random/2010-10/old/minetest-c55-win32-101024164856.zip) is available (works in wine).
 
-[toc]
-
 ## Map (the voxels)
 ![Minetest Voxel Storage](/images/minetest_voxel_storage.webp)
 

--- a/content/Mapgen_memory_optimisations.md
+++ b/content/Mapgen_memory_optimisations.md
@@ -5,8 +5,6 @@ This page intends to list all possible optimisation techniques that can be used 
 
 Lua map generators can use excessive memory if they are not using these 3 optimisations. Not using these optimizations can eventually lead to OOM (out-of-memory) errors because the Lua mapgen wasted way too much memory. Applying this advice is **strongly recommended**, and should make OOM errors much less likely. But there is no guarantee this will fix all OOM errors, your mapgen might still use excessive memory for other reasons, or the computer just has very limited memory.
 
-[toc]
-
 ## Only create perlin noise objects once
 The noise object is created by `core.get_perlin_map()`. It has to be created inside `register_on_generated()` to be usable, but only needs to be created once, many mapgen mods create it for every mapchunk, this consumes memory unnecessarily.
 

--- a/content/Spawn_Algorithm.md
+++ b/content/Spawn_Algorithm.md
@@ -3,8 +3,6 @@ The **spawn algorithm** tries to find a suitable spawn or respawn position for p
 
 This page describes how Luanti's builtin spawn algorithm works, as of **version 5.7.0**. Note that individual mods and games can choose to override the spawning behavior. The setting `static_spawn_point` can also override it.
 
-[toc]
-
 ## Overview
 If the setting `static_spawn_point` is set, luanti will spawn new players at this position.
 


### PR DESCRIPTION
Used to populate the table of contents but here they don't do anything.