### PR TITLE
Import German translation notes from Devwiki, cleanup

### DIFF
--- a/content/engine-dev-process/code-style-guidelines.md
+++ b/content/engine-dev-process/code-style-guidelines.md
@@ -20,7 +20,7 @@ Use American English, but avoid idioms that may be difficult to understand by no
 
 In case your function parameters don't fit within the defined line length, use the following style. Indention for continuation lines is **exactly** two tabs.
 
-```
+```cpp
 void some_function_name(type1 param1, type2 param2, type3 param3,
 		type4 param4, type5 param5, type6 param6, type7 param7)
 {
@@ -31,7 +31,7 @@ void some_function_name(type1 param1, type2 param2, type3 param3,
 
 Sometimes with complex function declarations, it might be messy to define as many parameters as possible on the same line. This is acceptable too (and currently used in some places):
 
-```
+```cpp
 void some_function_name(
 		const ReallyBigLongTypeName &param1,
 		ReallyBigLongTypeName *param2,
@@ -53,7 +53,7 @@ No more than 7 parameters allowed (except for constructors).
 * Try to stay under 6 levels of indentation.
 * Add spaces between operators so they line up when appropriate (don't go overboard). For example:
 
-```
+```cpp
 np_terrain_base   = settings->getNoiseParams("mgv6_np_terrain_base");
 np_terrain_higher = settings->getNoiseParams("mgv6_np_terrain_higher");
 np_steepness      = settings->getNoiseParams("mgv6_np_steepness");
@@ -73,7 +73,7 @@ The above code looks really nice.
 * Use a space after `if`, `else`, `for`, `do`, `while`, `switch`, `case`, `try`, `catch`, etc.
 * When breaking conditionals, indent following lines of the conditional with two tabs and the statement body with one tab. For example:
 
-```
+```cpp
 for (std::vector<std::string>::iterator it = strings.begin();
 		it != strings.end();
 		++it) {
@@ -84,7 +84,7 @@ for (std::vector<std::string>::iterator it = strings.begin();
 
 * Align backslashes for multi-line macros with spaces:
 
-```
+```cpp
 #define FOOBAR(x) do {    \
 	int __temp = (x); \
 	foo(__temp);      \
@@ -102,7 +102,7 @@ This rule has already been explicitly stated in the [Linux kernel code style](ht
 
 Example:
 
-```
+```cpp
 if (foobar < 3) foobar = 45;      // Bad
 (foobar < 3 && (foobar = 45));    // Bad
 ```
@@ -112,7 +112,7 @@ Violating this rule will result in **instant rejection**.
 
 Examples of good if statement wordings:
 
-```
+```cpp
 if (foobar < 3)
 	foobar = 45;
 
@@ -127,7 +127,7 @@ if (foobar < 6) {
 
 Special exception to the standard bracing/indent rules for nested loops: If a nested loop iterates over a set of coordinates, it is permitted to omit the braces for all but the innermost loop and keep the outer loops at the same indentation level, like so:
 
-```
+```cpp
 for (s16 z = pmin.Z; z <= pmax.Z, z++)
 for (s16 y = pmin.Y; y <= pmax.Y; y++)
 for (s16 x = pmin.X; x <= pmax.X; x++) {
@@ -168,11 +168,10 @@ for (s16 x = pmin.X; x <= pmax.X; x++) {
 * Class definitions should go in header files.
 * Substantial methods (over 4 lines) should be defined outside of the class definition.
 * Functions not part of any class should use `lowercase_underscore_style()`.
-
 * Doxygen comments are acceptable, but **please** put them in the header file.
 * Don't make uninformative comments like this:
 
-```
+```cpp
 // Draw "Loading" screen
 draw_load_screen(L"Loading...", driver, font);
 ```
@@ -181,7 +180,7 @@ draw_load_screen(L"Loading...", driver, font);
 * Add comments to explain a non-trivial but important detail about the code, or explain behavior that is not obvious.
 * For comments with text, be sure to add a space between the text and the comment tokens:
 
-```
+```cpp
 DoThingHere();  // This does thing    <--- yes!
 DoThingHere();  /* This does thing */ <--- yes!
 
@@ -208,7 +207,7 @@ DoThingHere();//This does thing        <--- no!
 * Files should have includes for everything that they depend on. Don't depend on, eg, `"util/numeric.h"` including `<string>`!
 * Uniqueness when compiling headers is ensured by using `#pragma once`. ([Accepted by all coredevs](https://github.com/minetest/minetest/issues/6259))
 
-```
+```cpp
 #pragma once
 
 #include <string>

--- a/content/engine-dev-process/git-guidelines.md
+++ b/content/engine-dev-process/git-guidelines.md
@@ -8,8 +8,6 @@ aliases:
 # Git Guidelines
 This page is mostly directed to core team members with commit or triage access to upstream repositories.
 
-For instructions on basic usage, see [Git](/Git "Git").
-
 For determining who is allowed to do what, see [Organisation](/Organisation "Organisation").
 
 For guidelines about overall pull request quality, see [Merging core pull requests to upstream](/Merging_core_pull_requests_to_upstream "Merging core pull requests to upstream").

--- a/content/engine-dev-process/releasing-luanti.md
+++ b/content/engine-dev-process/releasing-luanti.md
@@ -49,14 +49,14 @@ The feature freeze and release date is set by core developers.
 
 ### Autogenerate files
 
-Also update the [translation](/Translation "Translation") templates:
+Also update the [translation](/translation) templates:
 
 *   Engine: Regenerate Gettext files with `util/updatepo.sh`. Note that before that, you most likely want to [import existing changes](#Update_translations_from_Weblate) first.
 *   Builtin: Change directory to `builtin`, then run `util/mod_translation_updater.py` from there
 
 Also ensure that the `language` setting enum values contains `en`: there is no "en" directory, but Luanti supports it.
 
-Read [Translation](/Translation "Translation") for details.
+Read [Translation](/translation) for details.
 
 ### Update source strings on Weblate
 
@@ -69,13 +69,13 @@ Before releasing
 
 ### Verify special translation strings
 
-The translation files contain a special string: [LANG\_CODE](https://hosted.weblate.org/translate/minetest/minetest/en/?q=LANG_CODE&checksum=&offset=1#translations) (see [Translating](/Translating "Translating")).
+The translation files contain a special string: [LANG\_CODE](https://hosted.weblate.org/translate/minetest/minetest/en/?q=LANG_CODE&checksum=&offset=1#translations) (see [Translation](/translation)).
 
 Verify that all \*.po files have a valid value for these strings because translators frequently misunderstand them and enter an invalid value. Fix any invalid values on Weblate by either entering the correct one or by removing the bad translation.
 
 ### Update translations from Weblate
 
-**How to do this** -> [Translating#How\_to\_merge\_translations\_from\_Hosted\_Weblate](/Translating#How_to_merge_translations_from_Hosted_Weblate "Translating")
+**How to do this** -> [How to merge translations from Hosted Weblate](/translation/#how-to-merge-translations-from-hosted-weblate)
 
 If doing a backported release, you can use the following command to cherry-pick all translation commits from weblate:
 

--- a/content/engine/_index.md
+++ b/content/engine/_index.md
@@ -26,6 +26,6 @@ How to help improve documentation
 * Doxygen: We want to document most or all of Luanti core with [Doxygen-style](http://en.wikipedia.org/wiki/Doxygen) code comments.
 
 * The usage of doxygen is explained [there](http://www.doxygen.nl/manual/index.html).
-* Head over to #minetest-dev on IRC, and ask someone there to help you get started with documentation. You'll need to download the project through [Git](/Git "Git") and then make your changes.
+* Head over to #minetest-dev on IRC, and ask someone there to help you get started with documentation. You'll need to download the project through Git and then make your changes.
 
 * Move stuff from [NMPR](/Engine/NMPR "Engine/NMPR") to [Engine Structure](/Engine/Structure "Engine/Structure"), and improve [Engine Structure](/Engine/Structure "Engine/Structure") generally.

--- a/content/mod-interoperability.md
+++ b/content/mod-interoperability.md
@@ -35,7 +35,7 @@ For further discussion of the problem with `set_physics_override`, see [Player p
 
 #### Internationalization
 
-Since version 5.0.0, the preferred way to make mods and games translatable is with help of the Lua API with `core.get_translator`. No additional mod is required. Refer to `lua_api.md` or [the modding book chapter on translation](https://rubenwardy.com/minetest_modding_book/en/quality/translations.html) to learn how it works.
+Since version 5.0.0, the preferred way to make mods and games translatable is with help of the Lua API with `core.get_translator`. No additional mod is required. See [Translating Mods and Games](/translation/mods-and-games).
 
 #### Help
 

--- a/content/translation/_index.md
+++ b/content/translation/_index.md
@@ -1,6 +1,7 @@
 ---
 title: Translation
 aliases:
+- /Translating
 - /Translation
 bookCollapseSection: true
 ---
@@ -16,12 +17,6 @@ Translations of the Luanti engine are [automated using Weblate](https://hosted.w
 The developers usually will update the translation templates shortly before a new release. If you translate a long time before a release, your translation updates will still be included, but your translation will likely be incomplete because almost every new version comes with new things to translate. Check out the [News forum](https://forum.luanti.org/viewforum.php?f=18) to see if a new release is imminent.
 
 In case you wish to translate a new language, send a message in #minetest-dev and a coredev can add it.
-
-### Language-specific notes
-
-Here is a list of wiki pages for translating specific languages:
-
-* [German](/Translating/de "Translating/de")
 
 ### Special strings
 
@@ -49,7 +44,7 @@ Luanti detects the current language by inspecting the `LANG` environment variabl
 
 The available translations are found in source form in the `po/` directory. The `cmake` detects them, and they are built as part of the build process.
 
-The main translation file must be updated now and then using the [this script](https://github.com/minetest/minetest/blob/master/builtin/mainmenu/dlg_settings_advanced.lua) (configuration, bottom of the file) and [this one](https://github.com/minetest/minetest/blob/master/util/updatepo.sh) (C++ and Lua translations). Submit a PR after running the generator or poke a core dev to update the translations when it's needed. Note that builtin translations are handled separately, see the maintenance notes below.
+The main translation file must be updated now and then using the [this script](https://github.com/minetest/minetest/blob/master/builtin/mainmenu/settings/generate_from_settingtypes.lua) (configuration) and [this one](https://github.com/minetest/minetest/blob/master/util/updatepo.sh) (C++ and Lua translations). Submit a PR after running the generator or poke a core dev to update the translations when it's needed. Note that builtin translations are handled separately, see the maintenance notes below.
 
 Maintaining engine translations
 -------------------------------
@@ -104,7 +99,7 @@ To start a new translation, copy `template.txt` to create `__builtin.<LANGUAGE_C
 Translating mods and games
 --------------------------
 
-To learn how Luanti mods and games are translated, go to [Translation/Mods and Games](/Translation/Mods_and_Games "Translation/Mods and Games").
+To learn how Luanti mods and games are translated, go to [Translating Mods and Games](/translation/mods-and-games).
 
 Untranslatable texts
 --------------------

--- a/content/translation/_index.md
+++ b/content/translation/_index.md
@@ -18,6 +18,12 @@ The developers usually will update the translation templates shortly before a ne
 
 In case you wish to translate a new language, send a message in #minetest-dev and a coredev can add it.
 
+### Language-specific notes
+
+Here is a list of wiki pages for translating specific languages:
+
+* [German](/translation/de)
+
 ### Special strings
 
 In the translations you will find one string with a special meaning. It must **not** be translated literally. They are used internally by Luanti to trigger certain settings. You must enter a special value into the translation field.

--- a/content/translation/de.md
+++ b/content/translation/de.md
@@ -1,0 +1,75 @@
+---
+title: German translation notes
+aliases:
+  - /Translating/de
+---
+
+# German translation notes
+
+This page contains information for German translators.
+
+## Wiederkehrende Übersetzungen
+
+Hier gibt es eine Sammlung von Luanti-spezifischen Vokabeln, die der Konsistenz zuliebe immer gleich übersetzt werden sollten. Wenn ein besonderer Ausdruck auftauchen sollte, der hier noch nicht aufgeführt wurde, bitte an den bestehenden Übersetzungen orientieren und hier einfügen.
+
+### Substantive
+
+| Original                          | Übersetzung                             | Geschlecht | Kommentar                                                                                                                                                                                      |
+| --------------------------------- | --------------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| _anisotropic filtering_           | _Anisotroper Filter_                    | m          |                                                                                                                                                                                                |
+| _automatic forwards_              | _Vorwärtsautomatik_ oder _Autovorwärts_ | f          |                                                                                                                                                                                                |
+| _block_ / _mapblock_              | _Kartenblock_                           | m          | Hier ist besonders darauf zu achten, nicht „Block" zu nehmen, da es sonst mit „node" verwechselt wird.                                                                                         |
+| _cave_                            | _Höhle_                                 | f          |                                                                                                                                                                                                |
+| _cavern_                          | _Hohlraum_                              | m          |                                                                                                                                                                                                |
+| _Cinematic Mode_                  | _Filmmodus_                             | m          | Nicht _Kinomodus_, da es zum Filmen geeignet ist.                                                                                                                                              |
+| _client_                          | _Client_                                | m          |                                                                                                                                                                                                |
+| _Creative Mode_ / _creative mode_ | _Kreativmodus_                          | m          |                                                                                                                                                                                                |
+| _content store_                   | _Inhaltespeicher_                       | m          |                                                                                                                                                                                                |
+| _dungeon_                         | _Verlies_                               | n          |                                                                                                                                                                                                |
+| _entity_, _entities_              | _Entity_, _Entitys_                     | n          |                                                                                                                                                                                                |
+| _flags_                           | _Flags_                                 | f          | Klassische Eindeutschung eines Fremdworts; das Konzept ist schwer mit einem anderen Wort wiederzuspiegeln                                                                                      |
+| _floatland_ / _floatlands_        | _Schwebeland_ / _Schwebeländer_         | n          | Schwebende Landmassen, spezielle Funktion im v7-Kartengenerator (siehe [1](/mapgen/features#floatlands-experimental))                                                                          |
+| _hotbar_                          | _Schnellleiste_                         | f          |                                                                                                                                                                                                |
+| _game_                            | _Spiel_                                 | n          | Siehe [2](https://wiki.luanti.org/Games)                                                                                                                                                       |
+| _instrumentation_                 | _Instrumentierung_                      | f          | Siehe: [3](<https://de.wikipedia.org/wiki/Instrumentierung_(Softwareentwicklung)>)                                                                                                             |
+| _item_                            | _Gegenstand_                            | m          | Als „item" wird alles bezeichnet, was man mit sich im Inventar tragen kann. Das umfasst alle Blöcke (z.B. Sand), Werkzeuge (z.B. Spitzhacke) und sonstige Dinge (z.B. Kohleklumpen oder Buch). |
+| _lacunarity_                      | _Lückenhaftigkeit_                      | f          | Fachbegriff aus der Mathematik. Siehe: [4](https://www.dict.cc/?s=lacunarity)                                                                                                                  |
+| _map_                             | _Karte_                                 | f          |                                                                                                                                                                                                |
+| _mapchunk_                        | _Mapchunk_                              | m          | Noch eine „faule" Eindeutschung eines Fremdworts. Siehe [Terminology](/terminology)                                                                                                            |
+| _mapgen_ / _map generator_        | _Kartengenerator_                       | m          |                                                                                                                                                                                                |
+| _mod_                             | _Mod_                                   | f          | die _Modifikation_                                                                                                                                                                             |
+| _modpack_                         | _Modpack_                               | n          | das „Mod-Paket"                                                                                                                                                                                |
+| _node_                            | _Block_                                 | m          | Die wörtliche Übersetzung wäre „Knoten", was aber sehr irreführend wäre.                                                                                                                       |
+| _noclip_                          | _Geistmodus_                            | m          |                                                                                                                                                                                                |
+| _mesh_                            | _Mesh_                                  | f          | Gemeint ist „polygon mesh", siehe [5](https://en.wikipedia.org/wiki/Polygon_mesh)                                                                                                              |
+| _minimap_                         | _Übersichtskarte_                       | f          | Kann bei Platzmangel auch zu „Karte" abgekürzt werden                                                                                                                                          |
+| _noise_                           | _Rauschen_                              | n          |                                                                                                                                                                                                |
+| _noise param_ / _noise parameter_ | _Rauschparameter_                       | m          |                                                                                                                                                                                                |
+| _ridge_                           | _Flusskanal_                            | m          | Kontext: Die breiten Flüsse in v7, erzeugt vom „ridges"-Flag. Siehe [6](/mapgen/features#rivers)                                                                                               |
+| _shader_                          | _Shader_                                | m          |                                                                                                                                                                                                |
+| _screenshot_                      | _Bildschirmfoto_                        | n          |                                                                                                                                                                                                |
+| _special_                         | _Spezial_                               |            | Name einer Taste                                                                                                                                                                               |
+| _threshold_                       | _Schwellwert_                           | m          | Kontext: Kartengenerator                                                                                                                                                                       |
+| _tone mapping_                    | _Dynamikkompression_                    | m          |                                                                                                                                                                                                |
+| _spawn point_                     | _Einstiegsposition_                     | f          | Position, in der neue oder wiederbelebte Spieler auftauchen                                                                                                                                    |
+| _world_                           | _Welt_                                  | f          |                                                                                                                                                                                                |
+
+### Verben
+
+| Original        | Übersetzung       | Kommentar                                                                          |
+| --------------- | ----------------- | ---------------------------------------------------------------------------------- |
+| to _instrument_ | _instrumentieren_ | Siehe: [7](<https://de.wikipedia.org/wiki/Instrumentierung_(Softwareentwicklung)>) |
+| to _render_     | _rendern_         |
+| to _sneak_      | _schleichen_      |
+
+### Adjektive
+
+| Original     | Übersetzung | Kommentar                                                                |
+| ------------ | ----------- | ------------------------------------------------------------------------ |
+| _deprecated_ | _veraltet_  | Siehe [8](https://en.wikipedia.org/wiki/Deprecated#Software_deprecation) |
+
+## Sonstiges
+
+- Benutzer werden in der Höflichkeitsform („Sie") angeredet
+- Anführungszeichen: „ "
+- Innere Anführungszeichen: ‚ '

--- a/content/translation/mods-and-games.md
+++ b/content/translation/mods-and-games.md
@@ -1,11 +1,12 @@
 ---
 title: Translating Mods and Games
 aliases:
+- /Translation/Mods_and_Games
 - "/translation_mods_and_games"
 ---
 
-# Translation/Mods and Games
-This page explains how to translate mods and games for Luanti. To learn how Luanti itself (the engine) is translated, see [Translation](/Translation "Translation").
+# Translating Mods and Games
+This page explains how to translate mods and games for Luanti. To learn how Luanti itself (the engine) is translated, see [Translation](/translation).
 
 Before you begin
 ----------------
@@ -136,4 +137,4 @@ If you’re stuck with TR, the [modtools](https://github.com/minetest/modtools) 
 
 It is very useful for translators to be able to translate your thing in the browser.
 
-[Translating a game on Weblate](/Translating_a_game_on_Weblate "Translating a game on Weblate") is an useful guide on how to set up your game on a Weblate instance for allowing translation in the browser.
+[Translating a game on Weblate](/translation/weblate) is an useful guide on how to set up your game on a Weblate instance for allowing translation in the browser.

--- a/content/translation/weblate.md
+++ b/content/translation/weblate.md
@@ -114,4 +114,4 @@ You can optionally set up a push URL in Weblate to automate this but this is out
 See also
 --------
 
-* [Translation/Mods and Games](/Translation/Mods_and_Games "Translation/Mods and Games")
+* [Translating Mods and Games](/translation/mods-and-games)


### PR DESCRIPTION
- Code style guidelines formatting
- Clean up translation pages
- Import German language-specific notes page (high quality, probably was maintained by Wuzzy)
  - Problem: old Devwiki is no longer online, the most up-to-date version I could find was https://github.com/rollerozxa/mt-wiki-dumping-ground/blob/master/raw-exports/Minetest%2BDeveloper%2BWiki-20230713184411.xml -> the imported version may be outdated
- Remove links to not-imported Git page (see https://github.com/minetest/dev.luanti.org/issues/1#issuecomment-2526384803)

maybe not squash this, the commits are mostly unrelated