### PR TITLE
Add WIP site notice

### DIFF
--- a/layouts/partials/docs/inject/content-before.html
+++ b/layouts/partials/docs/inject/content-before.html
@@ -61,7 +61,7 @@
     // If JavaScript is enabled, add a close button and track the state in session storage (not saved across sessions)
     const site_notice = document.getElementById("site-notice");
 
-    if (sessionStorage.getItem("notice-closed") == "true") {
+    if (localStorage.getItem("notice-closed") == "true") {
         site_notice.remove();
     } else {
         const notice_close = document.createElement("div");
@@ -70,7 +70,7 @@
 
         notice_close.addEventListener("click", (e) => {
             e.currentTarget.parentElement.remove();
-            sessionStorage.setItem("notice-closed", "true");
+            localStorage.setItem("notice-closed", "true");
         })
 
         site_notice.appendChild(notice_close);

--- a/layouts/partials/docs/inject/content-before.html
+++ b/layouts/partials/docs/inject/content-before.html
@@ -1,0 +1,78 @@
+<!-- Site notice -->
+
+<style>
+    #site-notice {
+        position: relative;
+        margin: 2em 0;
+        margin-top: 0;
+        padding: 1em;
+        background-color: #5a83a5;
+        border: 4px solid #335f88;
+        border-radius: 1em;
+    }
+
+    #site-notice * {
+        margin: 0;
+        padding: 0;
+    }
+
+    #site-notice h3 {
+        margin-bottom: 0.5em;
+        font-weight: bold;
+    }
+
+    #site-notice a {
+        color: #f5b642;
+    }
+
+    #site-notice a:hover {
+        color: #ffd78c;
+    }
+
+    #site-notice #notice-close {
+        position: absolute;
+        top: 0;
+        right: 0;
+        visibility: hidden;
+        width: 1em;
+        cursor: pointer;
+        font-size: 1.5em;
+        line-height: 1em;
+    }
+
+    #site-notice:hover #notice-close {
+        visibility: visible;
+    }
+
+    #site-notice #notice-close:hover {
+        color: #c7c7c7;
+    }
+</style>
+
+<div id="site-notice">
+    <h3>NOTICE</h3>
+    <p>
+        {{ $about := .Site.GetPage "/about-this-site" }}
+        This site is a <strong>work in progress</strong> under active development! Content and URLs may change quickly without notice. Refer to <a href="{{ $about.Permalink }}">the About page</a> for information on the mission statement, roadmap, and how to contribute.
+    </p>
+</div>
+
+<script>
+    // If JavaScript is enabled, add a close button and track the state in session storage (not saved across sessions)
+    const site_notice = document.getElementById("site-notice");
+
+    if (sessionStorage.getItem("notice-closed") == "true") {
+        site_notice.remove();
+    } else {
+        const notice_close = document.createElement("div");
+        notice_close.id = "notice-close";
+        notice_close.innerHTML = "&times;";
+
+        notice_close.addEventListener("click", (e) => {
+            e.currentTarget.parentElement.remove();
+            sessionStorage.setItem("notice-closed", "true");
+        })
+
+        site_notice.appendChild(notice_close);
+    }
+</script>

--- a/layouts/partials/docs/inject/content-before.html
+++ b/layouts/partials/docs/inject/content-before.html
@@ -50,7 +50,7 @@
 </style>
 
 <div id="site-notice">
-    <h3>NOTICE</h3>
+    <h3>Notice</h3>
     <p>
         {{ $about := .Site.GetPage "/about-this-site" }}
         This site is a <strong>work in progress</strong> under active development! Content and URLs may change quickly without notice. Refer to <a href="{{ $about.Permalink }}">the About page</a> for information on the mission statement, roadmap, and how to contribute.
@@ -58,7 +58,7 @@
 </div>
 
 <script>
-    // If JavaScript is enabled, add a close button and track the state in session storage (not saved across sessions)
+    // If JavaScript is enabled, add a close button and track the state in local storage
     const site_notice = document.getElementById("site-notice");
 
     if (localStorage.getItem("notice-closed") == "true") {


### PR DESCRIPTION
Resolves #71.

Notice appears on all pages. If JavaScript is enabled, a close button is added (close state is tracked for current session only).

![image](https://github.com/user-attachments/assets/2305b762-2cf6-4da8-8286-96e9c4b3754b)
