### PR TITLE
Fix comments

### DIFF
--- a/content/about-this-site/local-development.md
+++ b/content/about-this-site/local-development.md
@@ -38,11 +38,11 @@ You can disable the spell checker without triggering build warnings using Hugo's
 ```md
 This text is spell-checked.
 
-{{/* cspell:disable */}}
+{{% comment %}} cspell:disable {{% /comment %}}
 
 The text is not splel-checked ;)
 
-{{/* cspell:enable */}}
+{{% comment %}} cspell:enable {{% /comment %}}
 
 Finally, this text is spell-checked again.
 ```

--- a/content/translation/mods-and-games.md
+++ b/content/translation/mods-and-games.md
@@ -80,7 +80,7 @@ In the texts (both original and translated texts), some characters will be repla
 
 Consider the example mod `example`. You will find the file `template.txt` with this content:
 
-{{/* cspell:disable */}}
+{{% comment %}} cspell:disable {{% /comment %}}
 ```
 # textdomain:example
 Apple=
@@ -92,11 +92,11 @@ E-mail: <somebody@@example.org>=
 “@=” is the equals sign=
 This text@nhas 2 lines.=Dieser Text@nhat 2 Zeilen.
 ```
-{{/* cspell:enable */}}
+{{% comment %}} cspell:enable {{% /comment %}}
 
 A possible translation in German would be stored under `example.de.tr` with this content:
 
-{{/* cspell:disable */}}
+{{% comment %}} cspell:disable {{% /comment %}}
 ```
 # textdomain:example
 Apple=Apfel
@@ -108,16 +108,16 @@ E-mail: <somebody@@example.org>=E-Mail: <somebody@@example.org>
 “@=” is the equals sign.=»@=« ist das Gleichheitszeichen.
 This text@nhas 2 lines.=Dieser Text@nhat 2 Zeilen.
 ```
-{{/* cspell:enable */}}
+{{% comment %}} cspell:enable {{% /comment %}}
 
 For reference, this is how the English texts could _actually_ show up in Luanti (with the placeholders resolved):
 
 * Apple
 * Pickaxe
 * Welcome, Merlin!
-{{/* cspell:disable */}}
+{{% comment %}} cspell:disable {{% /comment %}}
 * Gnerf has killed Hormel and gained 500 EXP.
-{{/* cspell:enable */}}
+{{% comment %}} cspell:enable {{% /comment %}}
 * E-mail: <somebody@example.org>
 * “=” is the equals sign
 * This text

--- a/layouts/shortcodes/comment.html
+++ b/layouts/shortcodes/comment.html
@@ -1,0 +1,2 @@
+<!-- Allows developers to add comments to Markdown files, ref `local-development.md` for details -->
+{{ if .Inner }}{{ end }}


### PR DESCRIPTION
Currently, `cspell:disable` comments are visible at https://dev.luanti.org/translation/mods-and-games/#example

This PR adds a custom comment shortcode for developers stuck on old versions of Hugo. It also fixes the comment syntax across the repo (2 files). cspell is still correctly disabled with the new syntax :)

Ref #96, https://stackoverflow.com/a/45252545/7711895

New site does not have the comment text anymore:

![image](https://github.com/user-attachments/assets/7ecca190-4f43-423a-bbc3-2b2a05ec39e1)