### PR TITLE
Fixup About This Site

### DIFF
--- a/content/about-this-site/_index.md
+++ b/content/about-this-site/_index.md
@@ -6,14 +6,14 @@ bookCollapseSection: true
 # About This Site
 
 This site is created using [Hugo](https://gohugo.io/), with theme [Hugo Book](https://themes.gohugo.io/themes/hugo-book/). 
-The sites source content can be found [here](https://github.com/minetest/dev.luanti.org/tree/master/content).
+The site's source content can be found [on GitHub](https://github.com/minetest/dev.luanti.org/tree/master/content).
 
 ## Contributing
 
-* [Making Changes](/about-this-site/making-changes/)
-* [Guidelines](/about-this-site/guidelines/)
-* [Setting up & running the site locally](/about-this-site/local-development/)
-* [Rules](/about-this-site/rules/)
+* [Making Changes](making-changes.md)
+* [Guidelines](guidelines.md)
+* [Setting up & running the site locally](local-development.md)
+* [Rules](rules.md)
 
 # Mission Statement
 
@@ -23,4 +23,4 @@ Luanti Documentation will be the central resource for the Luanti project as a wh
 * Engine reference and internal structures
 * Server and platform (player-facing) usage and guides
 
-Our Roadmap can be found at [this issue](https://github.com/minetest/dev.luanti.org/issues/113).
+Our roadmap can be found at [GitHub issue #113: Roadmap](https://github.com/minetest/dev.luanti.org/issues/113).

--- a/content/about-this-site/_index.md
+++ b/content/about-this-site/_index.md
@@ -10,10 +10,10 @@ The site's source content can be found [on GitHub](https://github.com/minetest/d
 
 ## Contributing
 
-* [Making Changes](making-changes.md)
-* [Guidelines](guidelines.md)
-* [Setting up & running the site locally](local-development.md)
-* [Rules](rules.md)
+* [Making Changes](/about-this-site/making-changes/)
+* [Guidelines](/about-this-site/guidelines/)
+* [Setting up & running the site locally](/about-this-site/local-development/)
+* [Rules](/about-this-site/rules/)
 
 # Mission Statement
 


### PR DESCRIPTION
Fix links, typos, link text. Using "here" as link text is bad a11y as screen reader users will just hear the word "here" and not know what the link is to. Yes, they can then re-listen to the whole sentence, but it's common to listen to links without context to quickly get a feel for what the page links to.